### PR TITLE
AttachableThreadedLogger now implements AttachableLogger

### DIFF
--- a/AttachableThreadedLogger.php
+++ b/AttachableThreadedLogger.php
@@ -15,7 +15,7 @@
  * GNU General Public License for more details.
 */
 
-abstract class AttachableThreadedLogger extends \ThreadedLogger{
+abstract class AttachableThreadedLogger extends \ThreadedLogger implements AttachableLogger{
 
 	/** @var \Volatile|\ThreadedLoggerAttachment[] */
 	protected $attachments;
@@ -27,14 +27,20 @@ abstract class AttachableThreadedLogger extends \ThreadedLogger{
 	/**
 	 * @param ThreadedLoggerAttachment $attachment
 	 */
-	public function addAttachment(\ThreadedLoggerAttachment $attachment){
+	public function addAttachment(\LoggerAttachment $attachment){
+		if(!is_a($attachment, \ThreadedLoggerAttachment::class, true)){
+			throw new \TypeError("Expected ThreadedLoggerAttachment, got " . get_class($attachment));
+		}
 		$this->attachments[] = $attachment;
 	}
 
 	/**
 	 * @param ThreadedLoggerAttachment $attachment
 	 */
-	public function removeAttachment(\ThreadedLoggerAttachment $attachment){
+	public function removeAttachment(\LoggerAttachment $attachment){
+		if(!is_a($attachment, \ThreadedLoggerAttachment::class, true)){
+			throw new \TypeError("Expected ThreadedLoggerAttachment, got " . get_class($attachment));
+		}
 		foreach($this->attachments as $i => $a){
 			if($attachment === $a){
 				unset($this->attachments[$i]);


### PR DESCRIPTION
This pull request modifies `\AttachableThreadedLogger` to implement `\AttachableLogger`, this allows \AttachableThreadedLogger instances to be passed wherever `\AttachableLogger` is allowed.

This is achieved by widening the accepted parameters for  `AttachableThreadedLogger::addAttachment()` and `AttachableThreadedLogger:: removeAttachment()` to fall inline with the `\AttachableLogger` definitions. This means we have to check the attachment is thread-safe within the function itself which somewhat defeats the purpose of implementing the contract and will confuse IDE's/developers as it looks like any `\LoggerAttachment` is allowed.

This is really a trade-off between keeping the usefulness of `\AttachableThreadedLogger` limited by not implementing the `\AttachableLogger` contract or cutting our losses and confusing static analysis tools by enforcing the `\AttachableThreadedLogger` type directly in the method.

Ideally the logger contracts should be re-worked so this isn't a trade-off between functionality & static analysis tools but this is something that requires more planning and time to implement. An alternative quick-fix solution would be to make all `\LoggerAttachment` instances thread friendly and remove the `\ThreadedLoggerAttachment` completely (imo this sounds better than the changes in this PR but entails slightly more BC changes).